### PR TITLE
Prevent using :cl on Clozure.

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,5 +1,6 @@
 (in-package :cl-user)
 (defpackage liblmdb
+  (:use)
   (:export :+append+
            :+appenddup+
            :+bad-dbi+


### PR DESCRIPTION
At the moment, trying to load liblmdb in Clozure raises an error, because it redefines `cl:get`.

In some Lisps (Clozure, at least) packages :use :cl by default, so if you want a package with no imported symbols you have to specify it by providing an empty :use option. 
