### PR TITLE
env_set_mapsize parameter type

### DIFF
--- a/src/liblmdb.lisp
+++ b/src/liblmdb.lisp
@@ -231,7 +231,7 @@
 
 (cffi:defcfun ("mdb_env_set_mapsize" #.(swig-lispify "mdb_env_set_mapsize" 'function)) :int
   (env :pointer)
-  (size :pointer))
+  (size :unsigned-int))
 
 (cffi:defcfun ("mdb_env_set_maxreaders" #.(swig-lispify "mdb_env_set_maxreaders" 'function)) :int
   (env :pointer)


### PR DESCRIPTION
There seems to be a problem in type declaration, as LMDB docs specify `size` parameter to be `size_t`. As this function is not used in `lmdb` library, this problem wasn't noticed before.